### PR TITLE
fix sofa rpc log config

### DIFF
--- a/sofa-boot-starter/src/main/java/com/alipay/sofa/rpc/boot/SofaBootRpcInitializer.java
+++ b/sofa-boot-starter/src/main/java/com/alipay/sofa/rpc/boot/SofaBootRpcInitializer.java
@@ -22,6 +22,7 @@ import com.alipay.sofa.rpc.boot.common.SofaBootRpcRuntimeException;
 import com.alipay.sofa.rpc.boot.config.SofaBootRpcConfigConstants;
 import com.alipay.sofa.rpc.boot.container.SpringBridge;
 import com.alipay.sofa.rpc.boot.log.SofaBootRpcLoggerFactory;
+import com.alipay.sofa.rpc.log.factory.RpcLoggerFactory;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.env.Environment;
@@ -40,7 +41,9 @@ public class SofaBootRpcInitializer implements ApplicationContextInitializer<Con
 
         checkAppName(applicationContext.getEnvironment().getProperty(SofaBootRpcConfigConstants.APP_NAME));
 
-        initLog(applicationContext.getEnvironment());
+        initStarterLog(applicationContext.getEnvironment());
+
+        initRpcCoreLog(applicationContext.getEnvironment());
 
     }
 
@@ -51,9 +54,25 @@ public class SofaBootRpcInitializer implements ApplicationContextInitializer<Con
         }
     }
 
-    private void initLog(Environment environment) {
+    /**
+     * init sofa rpc starter log config
+     *
+     * @param environment
+     */
+    private void initStarterLog(Environment environment) {
         //log level
         String logLevelKey = Constants.LOG_LEVEL_PREFIX + SofaBootRpcLoggerFactory.RPC_LOG_SPACE;
+        SofaBootLogSpaceIsolationInit.initSofaBootLogger(environment, logLevelKey);
+    }
+
+    /**
+     * init sofa rpc log config
+     *
+     * @param environment
+     */
+    private void initRpcCoreLog(Environment environment) {
+        //log level
+        String logLevelKey = Constants.LOG_LEVEL_PREFIX + RpcLoggerFactory.RPC_LOG_SPACE;
         SofaBootLogSpaceIsolationInit.initSofaBootLogger(environment, logLevelKey);
     }
 }


### PR DESCRIPTION
### Motivation:

to make sofa rpc log can be configured by application.properties

### Modification:

in com.alipay.sofa.rpc.boot.SofaBootRpcInitializer

I add a method named initRpcCoreLog which use
```
com.alipay.sofa.rpc.log.factory.RpcLoggerFactory#RPC_LOG_SPACE
```
### Result:

Fixes https://github.com/alipay/sofa-rpc-boot-projects/issues/37
