### PR TITLE
Add metrics-lookout config

### DIFF
--- a/sofa-boot-starter/src/main/java/com/alipay/sofa/rpc/boot/config/SofaBootRpcProperties.java
+++ b/sofa-boot-starter/src/main/java/com/alipay/sofa/rpc/boot/config/SofaBootRpcProperties.java
@@ -99,7 +99,7 @@ public class SofaBootRpcProperties {
     private String      boundHost;
 
     // disable metrics
-    private String disableMetricsCollect;
+    private String      disableMetricsCollect;
 
     public SofaBootRpcProperties(Environment environment) {
         this.environment = environment;

--- a/sofa-boot-starter/src/main/java/com/alipay/sofa/rpc/boot/config/SofaBootRpcProperties.java
+++ b/sofa-boot-starter/src/main/java/com/alipay/sofa/rpc/boot/config/SofaBootRpcProperties.java
@@ -98,8 +98,8 @@ public class SofaBootRpcProperties {
     // bound server
     private String      boundHost;
 
-    // disable metrics
-    private String      disableMetricsCollect;
+    // disable lookout
+    private String      disableLookoutCollect;
 
     public SofaBootRpcProperties(Environment environment) {
         this.environment = environment;
@@ -456,13 +456,13 @@ public class SofaBootRpcProperties {
         this.h2cAcceptsSize = h2cAcceptsSize;
     }
 
-    public String getDisableMetricsCollect() {
-        return StringUtils.isEmpty(disableMetricsCollect) ? getDotString(new Object() {
-        }.getClass().getEnclosingMethod().getName()) : disableMetricsCollect;
+    public String getDisableLookoutCollect() {
+        return StringUtils.isEmpty(disableLookoutCollect) ? getDotString(new Object() {
+        }.getClass().getEnclosingMethod().getName()) : disableLookoutCollect;
     }
 
-    public void setDisableMetricsCollect(String disableMetricsCollect) {
-        this.disableMetricsCollect = disableMetricsCollect;
+    public void setDisableLookoutCollect(String disableLookoutCollect) {
+        this.disableLookoutCollect = disableLookoutCollect;
     }
 
     private String getDotString(String enclosingMethodName) {

--- a/sofa-boot-starter/src/main/java/com/alipay/sofa/rpc/boot/config/SofaBootRpcProperties.java
+++ b/sofa-boot-starter/src/main/java/com/alipay/sofa/rpc/boot/config/SofaBootRpcProperties.java
@@ -99,7 +99,7 @@ public class SofaBootRpcProperties {
     private String      boundHost;
 
     // disable lookout
-    private String      disableLookoutCollect;
+    private String      lookoutCollectDisable;
 
     public SofaBootRpcProperties(Environment environment) {
         this.environment = environment;
@@ -456,13 +456,13 @@ public class SofaBootRpcProperties {
         this.h2cAcceptsSize = h2cAcceptsSize;
     }
 
-    public String getDisableLookoutCollect() {
-        return StringUtils.isEmpty(disableLookoutCollect) ? getDotString(new Object() {
-        }.getClass().getEnclosingMethod().getName()) : disableLookoutCollect;
+    public String getLookoutCollectDisable() {
+        return StringUtils.isEmpty(lookoutCollectDisable) ? getDotString(new Object() {
+        }.getClass().getEnclosingMethod().getName()) : lookoutCollectDisable;
     }
 
-    public void setDisableLookoutCollect(String disableLookoutCollect) {
-        this.disableLookoutCollect = disableLookoutCollect;
+    public void setLookoutCollectDisable(String lookoutCollectDisable) {
+        this.lookoutCollectDisable = lookoutCollectDisable;
     }
 
     private String getDotString(String enclosingMethodName) {

--- a/sofa-boot-starter/src/main/java/com/alipay/sofa/rpc/boot/config/SofaBootRpcProperties.java
+++ b/sofa-boot-starter/src/main/java/com/alipay/sofa/rpc/boot/config/SofaBootRpcProperties.java
@@ -98,6 +98,9 @@ public class SofaBootRpcProperties {
     // bound server
     private String      boundHost;
 
+    // disable metrics
+    private String disableMetricsCollect;
+
     public SofaBootRpcProperties(Environment environment) {
         this.environment = environment;
     }
@@ -451,6 +454,15 @@ public class SofaBootRpcProperties {
 
     public void setH2cAcceptsSize(String h2cAcceptsSize) {
         this.h2cAcceptsSize = h2cAcceptsSize;
+    }
+
+    public String getDisableMetricsCollect() {
+        return StringUtils.isEmpty(disableMetricsCollect) ? getDotString(new Object() {
+        }.getClass().getEnclosingMethod().getName()) : disableMetricsCollect;
+    }
+
+    public void setDisableMetricsCollect(String disableMetricsCollect) {
+        this.disableMetricsCollect = disableMetricsCollect;
     }
 
     private String getDotString(String enclosingMethodName) {

--- a/sofa-boot-starter/src/main/java/com/alipay/sofa/rpc/boot/context/SofaBootRpcStartListener.java
+++ b/sofa-boot-starter/src/main/java/com/alipay/sofa/rpc/boot/context/SofaBootRpcStartListener.java
@@ -16,12 +16,16 @@
  */
 package com.alipay.sofa.rpc.boot.context;
 
+import com.alipay.sofa.rpc.boot.common.SofaBootRpcParserUtil;
 import com.alipay.sofa.rpc.boot.config.FaultToleranceConfigurator;
+import com.alipay.sofa.rpc.boot.config.SofaBootRpcProperties;
 import com.alipay.sofa.rpc.boot.container.ProviderConfigContainer;
 import com.alipay.sofa.rpc.boot.container.RegistryConfigContainer;
 import com.alipay.sofa.rpc.boot.container.ServerConfigContainer;
 import com.alipay.sofa.rpc.boot.context.event.SofaBootRpcStartEvent;
+import com.alipay.sofa.rpc.event.LookoutSubscriber;
 import com.alipay.sofa.rpc.registry.Registry;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationListener;
 
 /**
@@ -32,6 +36,10 @@ import org.springframework.context.ApplicationListener;
  * @author <a href="mailto:lw111072@antfin.com">LiWei</a>
  */
 public class SofaBootRpcStartListener implements ApplicationListener<SofaBootRpcStartEvent> {
+
+    @Autowired
+    private SofaBootRpcProperties sofaBootRpcProperties;
+
     private final ProviderConfigContainer    providerConfigContainer;
     private final FaultToleranceConfigurator faultToleranceConfigurator;
     private final ServerConfigContainer      serverConfigContainer;
@@ -50,6 +58,9 @@ public class SofaBootRpcStartListener implements ApplicationListener<SofaBootRpc
 
     @Override
     public void onApplicationEvent(SofaBootRpcStartEvent event) {
+        //choose disable metrics lookout
+        disableLookout();
+
         //start fault tolerance
         faultToleranceConfigurator.startFaultTolerance();
 
@@ -67,5 +78,13 @@ public class SofaBootRpcStartListener implements ApplicationListener<SofaBootRpc
 
         //export dubbo
         providerConfigContainer.exportAllDubboProvideConfig();
+    }
+
+    private void disableLookout() {
+        Boolean disable = SofaBootRpcParserUtil.parseBoolean(sofaBootRpcProperties.getDisableMetricsCollect());
+
+        if(disable != null){
+            LookoutSubscriber.setLookoutCollectDisable(disable);
+        }
     }
 }

--- a/sofa-boot-starter/src/main/java/com/alipay/sofa/rpc/boot/context/SofaBootRpcStartListener.java
+++ b/sofa-boot-starter/src/main/java/com/alipay/sofa/rpc/boot/context/SofaBootRpcStartListener.java
@@ -81,7 +81,7 @@ public class SofaBootRpcStartListener implements ApplicationListener<SofaBootRpc
     }
 
     private void disableLookout() {
-        Boolean disable = SofaBootRpcParserUtil.parseBoolean(sofaBootRpcProperties.getDisableMetricsCollect());
+        Boolean disable = SofaBootRpcParserUtil.parseBoolean(sofaBootRpcProperties.getDisableLookoutCollect());
 
         if (disable != null) {
             LookoutSubscriber.setLookoutCollectDisable(disable);

--- a/sofa-boot-starter/src/main/java/com/alipay/sofa/rpc/boot/context/SofaBootRpcStartListener.java
+++ b/sofa-boot-starter/src/main/java/com/alipay/sofa/rpc/boot/context/SofaBootRpcStartListener.java
@@ -81,7 +81,7 @@ public class SofaBootRpcStartListener implements ApplicationListener<SofaBootRpc
     }
 
     private void disableLookout() {
-        Boolean disable = SofaBootRpcParserUtil.parseBoolean(sofaBootRpcProperties.getDisableLookoutCollect());
+        Boolean disable = SofaBootRpcParserUtil.parseBoolean(sofaBootRpcProperties.getLookoutCollectDisable());
 
         if (disable != null) {
             LookoutSubscriber.setLookoutCollectDisable(disable);

--- a/sofa-boot-starter/src/main/java/com/alipay/sofa/rpc/boot/context/SofaBootRpcStartListener.java
+++ b/sofa-boot-starter/src/main/java/com/alipay/sofa/rpc/boot/context/SofaBootRpcStartListener.java
@@ -38,7 +38,7 @@ import org.springframework.context.ApplicationListener;
 public class SofaBootRpcStartListener implements ApplicationListener<SofaBootRpcStartEvent> {
 
     @Autowired
-    private SofaBootRpcProperties sofaBootRpcProperties;
+    private SofaBootRpcProperties            sofaBootRpcProperties;
 
     private final ProviderConfigContainer    providerConfigContainer;
     private final FaultToleranceConfigurator faultToleranceConfigurator;
@@ -83,7 +83,7 @@ public class SofaBootRpcStartListener implements ApplicationListener<SofaBootRpc
     private void disableLookout() {
         Boolean disable = SofaBootRpcParserUtil.parseBoolean(sofaBootRpcProperties.getDisableMetricsCollect());
 
-        if(disable != null){
+        if (disable != null) {
             LookoutSubscriber.setLookoutCollectDisable(disable);
         }
     }


### PR DESCRIPTION
### Motivation:

Add a switch to disable metrics.

### Modification:

Add `disableMetricsCollect` in com.alipay.sofa.rpc.boot.config.SofaBootRpcProperties. And  it will be set up after health check.

### Result:
If you add a configuration item: `com.alipay.sofa.rpc.disable.metrics.collect=true`. metrics will not take effect.
