### PR TITLE
Exclude commons-logging dependency

### DIFF
--- a/sofa-boot-core/pom.xml
+++ b/sofa-boot-core/pom.xml
@@ -115,6 +115,12 @@
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-multipart-provider</artifactId>
             <version>${resteasy.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>commons-logging</artifactId>
+                    <groupId>commons-logging</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>javax.el</groupId>


### PR DESCRIPTION
Commons-logging disables spring boot log when project add rpc-sofa-boot-starter. 