### PR TITLE
Add serlize type support in annotation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.alipay.sofa</groupId>
     <artifactId>sofa-rpc-boot-projects</artifactId>
-    <version>6.0.0</version>
+    <version>6.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/sofa-boot-core/pom.xml
+++ b/sofa-boot-core/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.alipay.sofa</groupId>
         <artifactId>sofaboot-dependencies</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>rpc-sofa-boot-core</artifactId>
-    <version>6.0.0</version>
+    <version>6.0.1-SNAPSHOT</version>
 
     <url>https://github.com/alipay/sofa-rpc</url>
 

--- a/sofa-boot-core/src/main/java/com/alipay/sofa/rpc/boot/runtime/converter/RpcBindingConverter.java
+++ b/sofa-boot-core/src/main/java/com/alipay/sofa/rpc/boot/runtime/converter/RpcBindingConverter.java
@@ -371,6 +371,9 @@ public abstract class RpcBindingConverter implements BindingConverter<RpcBinding
         if (sofaServiceBindingAnnotation.warmUpWeight() != 0) {
             bindingParam.setWarmUpWeight(sofaServiceBindingAnnotation.warmUpWeight());
         }
+        if (StringUtils.hasText(sofaServiceBindingAnnotation.serializeType())) {
+            bindingParam.setSerialization(sofaServiceBindingAnnotation.serializeType());
+        }
 
         ApplicationContext applicationContext = bindingConverterContext.getApplicationContext();
         List<Filter> filters = new ArrayList<Filter>(RpcFilterContainer.getInstance().getFilters(
@@ -445,6 +448,9 @@ public abstract class RpcBindingConverter implements BindingConverter<RpcBinding
         }
         if (sofaReferenceBindingAnnotation.timeout() != 0) {
             bindingParam.setTimeout(sofaReferenceBindingAnnotation.timeout());
+        }
+        if (StringUtils.hasText(sofaReferenceBindingAnnotation.serializeType())) {
+            bindingParam.setSerialization(sofaReferenceBindingAnnotation.serializeType());
         }
         bindingParam.setType(sofaReferenceBindingAnnotation.invokeType());
 

--- a/sofa-boot-plugin/pom.xml
+++ b/sofa-boot-plugin/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.alipay.sofa</groupId>
         <artifactId>sofaboot-dependencies</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>rpc-sofa-boot-plugin</artifactId>
-    <version>6.0.0</version>
+    <version>6.0.1-SNAPSHOT</version>
 
     <properties>
         <ark.plugin.name>rpc-sofa-boot-plugin</ark.plugin.name>
@@ -144,7 +144,7 @@
                         <configuration>
                             <priority>2000</priority>
                             <pluginName>${ark.plugin.name}</pluginName>
-                            <classifier> </classifier>
+                            <classifier></classifier>
 
                             <exported>
                                 <packages>

--- a/sofa-boot-samples/pom.xml
+++ b/sofa-boot-samples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.alipay.sofa</groupId>
         <artifactId>sofa-rpc-boot-projects</artifactId>
-        <version>6.0.0</version>
+        <version>6.0.1-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/sofa-boot-samples/pom.xml
+++ b/sofa-boot-samples/pom.xml
@@ -14,7 +14,7 @@
         <dubbo_version>2.4.10</dubbo_version>
         <cxf.version>3.0.14</cxf.version>
         <sofaboot.version>3.0.0</sofaboot.version>
-        <rpc.starter.version>6.0.0</rpc.starter.version>
+        <rpc.starter.version>6.0.1-SNAPSHOT</rpc.starter.version>
     </properties>
 
     <artifactId>rpc-sofa-boot-samples</artifactId>

--- a/sofa-boot-starter/pom.xml
+++ b/sofa-boot-starter/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.alipay.sofa</groupId>
         <artifactId>sofaboot-dependencies</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>rpc-sofa-boot-starter</artifactId>
-    <version>6.0.0</version>
+    <version>6.0.1-SNAPSHOT</version>
 
     <url>https://github.com/alipay/sofa-rpc</url>
 

--- a/sofa-boot-starter/pom.xml
+++ b/sofa-boot-starter/pom.xml
@@ -18,7 +18,7 @@
         <java.version>1.6</java.version>
         <project.build.encoding>UTF-8</project.build.encoding>
         <skipTests>false</skipTests>
-        <rpc.starter.version>6.0.0</rpc.starter.version>
+        <rpc.starter.version>6.0.1-SNAPSHOT</rpc.starter.version>
     </properties>
 
     <dependencies>

--- a/sofa-boot-starter/src/test/java/com/alipay/sofa/rpc/boot/SofaBootRpcAllTest.java
+++ b/sofa-boot-starter/src/test/java/com/alipay/sofa/rpc/boot/SofaBootRpcAllTest.java
@@ -190,8 +190,8 @@ public class SofaBootRpcAllTest {
     // Encode on serialization should failed
     @Test
     public void testAnnotationProtobuf() {
-//        thrown.expect(SofaRpcException.class);
-//        thrown.expectMessage("com.alipay.remoting.exception.SerializationException: 0");
+        //        thrown.expect(SofaRpcException.class);
+        //        thrown.expectMessage("com.alipay.remoting.exception.SerializationException: 0");
         annotationServicePb.hello();
     }
 }

--- a/sofa-boot-starter/src/test/java/com/alipay/sofa/rpc/boot/SofaBootRpcAllTest.java
+++ b/sofa-boot-starter/src/test/java/com/alipay/sofa/rpc/boot/SofaBootRpcAllTest.java
@@ -19,6 +19,7 @@ package com.alipay.sofa.rpc.boot;
 import com.alipay.hessian.generic.model.GenericObject;
 import com.alipay.sofa.rpc.api.GenericService;
 import com.alipay.sofa.rpc.api.future.SofaResponseFuture;
+import com.alipay.sofa.rpc.boot.annotation.AnnotationService;
 import com.alipay.sofa.rpc.boot.direct.DirectService;
 import com.alipay.sofa.rpc.boot.dubbo.DubboService;
 import com.alipay.sofa.rpc.boot.filter.FilterService;
@@ -32,8 +33,13 @@ import com.alipay.sofa.rpc.boot.rest.RestService;
 import com.alipay.sofa.rpc.boot.retry.RetriesService;
 import com.alipay.sofa.rpc.boot.retry.RetriesServiceImpl;
 import com.alipay.sofa.rpc.boot.threadpool.ThreadPoolService;
+import com.alipay.sofa.rpc.core.exception.SofaRpcException;
+import com.alipay.sofa.runtime.api.annotation.SofaReference;
+import com.alipay.sofa.runtime.api.annotation.SofaReferenceBinding;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -46,6 +52,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 @RunWith(SpringRunner.class)
 @ImportResource("classpath*:spring/test_all.xml")
 public class SofaBootRpcAllTest {
+    @Rule
+    public ExpectedException     thrown = ExpectedException.none();
 
     @Autowired
     private HelloSyncService     helloSyncService;
@@ -89,9 +97,16 @@ public class SofaBootRpcAllTest {
     @Autowired
     private LazyService          lazyServiceDubbo;
 
+    @SofaReference(binding = @SofaReferenceBinding(bindingType = "bolt"),
+            jvmFirst = false)
+    private AnnotationService    annotationService;
+
+    @SofaReference(binding = @SofaReferenceBinding(bindingType = "bolt", serializeType = "protobuf"),
+            jvmFirst = false)
+    private AnnotationService    annotationServicePb;
+
     @Test
     public void testInvoke() throws InterruptedException {
-
         Assert.assertEquals("sync", helloSyncService.saySync("sync"));
 
         helloFutureService.sayFuture("future");
@@ -163,10 +178,20 @@ public class SofaBootRpcAllTest {
 
     @Test
     public void testLazy() {
-
         Assert.assertEquals("lazy_bolt", lazyServiceBolt.sayLazy("lazy_bolt"));
         Assert.assertEquals("lazy_dubbo", lazyServiceDubbo.sayLazy("lazy_dubbo"));
-
     }
 
+    @Test
+    public void testAnnotation() {
+        Assert.assertEquals("Hello, Annotation", annotationService.hello());
+    }
+
+    // Encode on serialization should failed
+    @Test
+    public void testAnnotationProtobuf() {
+        thrown.expect(SofaRpcException.class);
+        thrown.expectMessage("com.alipay.remoting.exception.SerializationException: 0");
+        annotationServicePb.hello();
+    }
 }

--- a/sofa-boot-starter/src/test/java/com/alipay/sofa/rpc/boot/SofaBootRpcAllTest.java
+++ b/sofa-boot-starter/src/test/java/com/alipay/sofa/rpc/boot/SofaBootRpcAllTest.java
@@ -190,8 +190,8 @@ public class SofaBootRpcAllTest {
     // Encode on serialization should failed
     @Test
     public void testAnnotationProtobuf() {
-        thrown.expect(SofaRpcException.class);
-        thrown.expectMessage("com.alipay.remoting.exception.SerializationException: 0");
+//        thrown.expect(SofaRpcException.class);
+//        thrown.expectMessage("com.alipay.remoting.exception.SerializationException: 0");
         annotationServicePb.hello();
     }
 }

--- a/sofa-boot-starter/src/test/java/com/alipay/sofa/rpc/boot/SofaBootRpcAllTest.java
+++ b/sofa-boot-starter/src/test/java/com/alipay/sofa/rpc/boot/SofaBootRpcAllTest.java
@@ -190,8 +190,8 @@ public class SofaBootRpcAllTest {
     // Encode on serialization should failed
     @Test
     public void testAnnotationProtobuf() {
-        //        thrown.expect(SofaRpcException.class);
-        //        thrown.expectMessage("com.alipay.remoting.exception.SerializationException: 0");
+        thrown.expect(SofaRpcException.class);
+        thrown.expectMessage("com.alipay.remoting.exception.SerializationException: 0");
         annotationServicePb.hello();
     }
 }

--- a/sofa-boot-starter/src/test/java/com/alipay/sofa/rpc/boot/annotation/AnnotationService.java
+++ b/sofa-boot-starter/src/test/java/com/alipay/sofa/rpc/boot/annotation/AnnotationService.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.boot.annotation;
+
+public interface AnnotationService {
+    String hello();
+}

--- a/sofa-boot-starter/src/test/java/com/alipay/sofa/rpc/boot/annotation/AnnotationServiceImpl.java
+++ b/sofa-boot-starter/src/test/java/com/alipay/sofa/rpc/boot/annotation/AnnotationServiceImpl.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.boot.annotation;
+
+import com.alipay.sofa.runtime.api.annotation.SofaService;
+import com.alipay.sofa.runtime.api.annotation.SofaServiceBinding;
+import org.springframework.stereotype.Component;
+
+@Component
+@SofaService(bindings = { @SofaServiceBinding(bindingType = "bolt") })
+public class AnnotationServiceImpl implements AnnotationService {
+    @Override
+    public String hello() {
+        return "Hello, Annotation";
+    }
+}

--- a/sofa-boot-starter/src/test/java/com/alipay/sofa/rpc/boot/annotation/AnnotationServicePbImpl.java
+++ b/sofa-boot-starter/src/test/java/com/alipay/sofa/rpc/boot/annotation/AnnotationServicePbImpl.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.boot.annotation;
+
+import com.alipay.sofa.runtime.api.annotation.SofaService;
+import com.alipay.sofa.runtime.api.annotation.SofaServiceBinding;
+import org.springframework.stereotype.Component;
+
+@Component
+@SofaService(bindings = { @SofaServiceBinding(bindingType = "bolt", serializeType = "protobuf") })
+public class AnnotationServicePbImpl implements AnnotationService {
+    @Override
+    public String hello() {
+        return null;
+    }
+}

--- a/sofa-boot-starter/src/test/resources/spring/test_all.xml
+++ b/sofa-boot-starter/src/test/resources/spring/test_all.xml
@@ -2,15 +2,18 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:sofa="http://sofastack.io/schema/sofaboot"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-            http://sofastack.io/schema/sofaboot   http://sofastack.io/schema/sofaboot.xsd">
+            http://sofastack.io/schema/sofaboot http://sofastack.io/schema/sofaboot.xsd
+            http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
 
     <!-- invoke sync-->
     <bean id="helloSyncServiceImpl" class="com.alipay.sofa.rpc.boot.invoke.HelloSyncServiceImpl"/>
     <sofa:service ref="helloSyncServiceImpl" interface="com.alipay.sofa.rpc.boot.invoke.HelloSyncService">
         <sofa:binding.bolt/>
     </sofa:service>
-    <sofa:reference jvm-first="false" id="helloSyncService" interface="com.alipay.sofa.rpc.boot.invoke.HelloSyncService">
+    <sofa:reference jvm-first="false" id="helloSyncService"
+                    interface="com.alipay.sofa.rpc.boot.invoke.HelloSyncService">
         <sofa:binding.bolt/>
     </sofa:reference>
 
@@ -19,7 +22,8 @@
     <sofa:service ref="helloFutureServiceImpl" interface="com.alipay.sofa.rpc.boot.invoke.HelloFutureService">
         <sofa:binding.bolt/>
     </sofa:service>
-    <sofa:reference jvm-first="false" id="helloFutureService" interface="com.alipay.sofa.rpc.boot.invoke.HelloFutureService">
+    <sofa:reference jvm-first="false" id="helloFutureService"
+                    interface="com.alipay.sofa.rpc.boot.invoke.HelloFutureService">
         <sofa:binding.bolt>
             <sofa:global-attrs type="future"/>
         </sofa:binding.bolt>
@@ -50,15 +54,16 @@
         <sofa:binding.bolt/>
     </sofa:reference>
 
-     <!--Global Filter Test-->
+    <!--Global Filter Test-->
     <sofa:rpc-global-filter ref="testGlobalFilter"/>
     <bean id="testGlobalFilter" class="com.alipay.sofa.rpc.boot.globalfilter.TestGlobalFilter"/>
 
-    <bean id="globalFilterServiceImpl" class="com.alipay.sofa.rpc.boot.globalfilter.GlobalFilterServiceImpl" />
+    <bean id="globalFilterServiceImpl" class="com.alipay.sofa.rpc.boot.globalfilter.GlobalFilterServiceImpl"/>
     <sofa:service ref="globalFilterServiceImpl" interface="com.alipay.sofa.rpc.boot.globalfilter.GlobalFilterService">
         <sofa:binding.bolt/>
     </sofa:service>
-    <sofa:reference jvm-first="false" id="globalFilterService" interface="com.alipay.sofa.rpc.boot.globalfilter.GlobalFilterService">
+    <sofa:reference jvm-first="false" id="globalFilterService"
+                    interface="com.alipay.sofa.rpc.boot.globalfilter.GlobalFilterService">
         <sofa:binding.bolt/>
     </sofa:reference>
 
@@ -131,13 +136,14 @@
             <sofa:global-attrs retries="2"/>
         </sofa:binding.bolt>
     </sofa:reference>
-    <sofa:reference jvm-first="false" id="retriesServiceDubbo" interface="com.alipay.sofa.rpc.boot.retry.RetriesService">
+    <sofa:reference jvm-first="false" id="retriesServiceDubbo"
+                    interface="com.alipay.sofa.rpc.boot.retry.RetriesService">
         <sofa:binding.dubbo>
             <sofa:global-attrs retries="2"/>
         </sofa:binding.dubbo>
     </sofa:reference>
 
-     <!-- lazy -->
+    <!-- lazy -->
     <bean id="lazyServiceImpl" class="com.alipay.sofa.rpc.boot.lazy.LazyServiceImpl"/>
     <sofa:service ref="lazyServiceImpl" interface="com.alipay.sofa.rpc.boot.lazy.LazyService">
         <sofa:binding.bolt/>
@@ -155,4 +161,7 @@
             <sofa:global-attrs lazy="true"/>
         </sofa:binding.dubbo>
     </sofa:reference>
+
+    <!-- Annotation TestCase -->
+    <context:component-scan base-package="com.alipay.sofa.rpc.boot.annotation"/>
 </beans>


### PR DESCRIPTION
### Motivation:

Add serialize type support in annotation

### Modification:

Add serialize type parse code in RpcBindingConverter when parse reference and service configuration.
### Result:

Fixes issue #116